### PR TITLE
Only test with ruby versions 2.7 and 3.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['2.7', '3.0']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Other versions fail with
```
wrong number of arguments (given 5, expected 1)
/opt/hostedtoolcache/Ruby/3.1.4/x64/lib/ruby/3.1.0/psych.rb:322:in `safe_load'
```