### PR TITLE
Support `group_alias` parameter for `remove_testers_action`.

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_remove_testers_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_remove_testers_action.rb
@@ -26,11 +26,15 @@ module Fastlane
           UI.user_error!("A maximum of 1000 testers can be removed at a time.")
         end
 
-        UI.message("⏳ Removing #{emails.count} testers from project #{params[:project_number]}...")
-
-        count = fad_api_client.remove_testers(params[:project_number], emails)
-
-        UI.success("✅ #{count} tester(s) removed successfully.")
+        if blank?(params[:group_alias])
+          UI.message("⏳ Removing #{emails.count} testers from project #{params[:project_number]}...")
+          count = fad_api_client.remove_testers(params[:project_number], emails)
+          UI.success("✅ #{count} tester(s) removed successfully.")
+        else
+          UI.message("⏳ Removing #{emails.count} testers from group #{params[:group_alias]}...")
+          fad_api_client.remove_testers_from_group(params[:project_number], params[:group_alias], emails)
+          UI.success("✅ Tester(s) removed successfully.")
+        end
       end
 
       def self.description
@@ -55,14 +59,19 @@ module Fastlane
                                        optional: false),
           FastlaneCore::ConfigItem.new(key: :emails,
                                       env_name: "FIREBASEAPPDISTRO_REMOVE_TESTERS_EMAILS",
-                                      description: "Comma separated list of tester emails to be deleted. A maximum of 1000 testers can be deleted at a time",
+                                      description: "Comma separated list of tester emails to be deleted (or removed from a group if a group alias is specified). A maximum of 1000 testers can be deleted/removed at a time",
                                       optional: true,
                                       type: String),
           FastlaneCore::ConfigItem.new(key: :file,
                                       env_name: "FIREBASEAPPDISTRO_REMOVE_TESTERS_FILE",
-                                      description: "Path to a file containing a comma separated list of tester emails to be deleted. A maximum of 1000 testers can be deleted at a time",
+                                      description: "Path to a file containing a comma separated list of tester emails to be deleted (or removed from a group if a group alias is specified). A maximum of 1000 testers can be deleted/removed at a time",
                                       optional: true,
                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :group_alias,
+                                       env_name: "FIREBASEAPPDISTRO_REMOVE_TESTERS_GROUP_ALIAS",
+                                       description: "Alias of the group to remove the specified testers from. Testers will not be deleted from the project",
+                                       optional: true,
+                                       type: String),
           FastlaneCore::ConfigItem.new(key: :service_credentials_file,
                                       description: "Path to Google service credentials file",
                                       optional: true,

--- a/spec/firebase_app_distribution_remove_testers_action_spec.rb
+++ b/spec/firebase_app_distribution_remove_testers_action_spec.rb
@@ -53,5 +53,34 @@ describe Fastlane::Actions::FirebaseAppDistributionRemoveTestersAction do
 
       action.run({ project_number: project_number, file: path })
     end
+
+    it 'removes testers only from the specified group when group_alias is specified' do
+      project_number = 1
+      emails = '1@e.mail,2@e.mail'
+      path = 'path/to/file'
+      fake_file = double('file')
+      group_alias = 'group_alias'
+      allow(File).to receive(:open)
+        .with(path)
+        .and_return(fake_file)
+      allow(fake_file).to receive(:read).and_return(emails)
+      expect_any_instance_of(Fastlane::Client::FirebaseAppDistributionApiClient).not_to(receive(:remove_testers))
+      expect_any_instance_of(Fastlane::Client::FirebaseAppDistributionApiClient).to receive(:remove_testers_from_group).with(project_number, group_alias, emails.split(','))
+      action.run({ project_number: project_number, file: path, group_alias: group_alias })
+    end
+
+    it 'does not makes any remove_testers_from_group calls when group_alias is not specified' do
+      project_number = 1
+      emails = '1@e.mail,2@e.mail'
+      path = 'path/to/file'
+      fake_file = double('file')
+      allow(File).to receive(:open)
+        .with(path)
+        .and_return(fake_file)
+      allow(fake_file).to receive(:read).and_return(emails)
+      expect_any_instance_of(Fastlane::Client::FirebaseAppDistributionApiClient).to receive(:remove_testers).with(project_number, emails.split(','))
+      expect_any_instance_of(Fastlane::Client::FirebaseAppDistributionApiClient).not_to(receive(:remove_testers_from_group))
+      action.run({ project_number: project_number, file: path })
+    end
   end
 end


### PR DESCRIPTION
 This removes the testers from only the specified group, but doesn't delete them from the project.