### PR TITLE
Support debug mode and client headers with generated API client

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_create_group_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_create_group_action.rb
@@ -22,9 +22,7 @@ module Fastlane
           UI.user_error!("Must specify `display_name`.")
         end
 
-        client = FirebaseAppDistributionV1::FirebaseAppDistributionService.new
-        client.authorization =
-          get_authorization(params[:service_credentials_file], params[:firebase_cli_token])
+        client = init_client(params[:service_credentials_file], params[:firebase_cli_token], params[:debug])
 
         project_number = params[:project_number]
         group_alias = params[:alias]

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_delete_group_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_delete_group_action.rb
@@ -10,12 +10,8 @@ module Fastlane
       extend Auth::FirebaseAppDistributionAuthClient
       extend Helper::FirebaseAppDistributionHelper
 
-      FirebaseAppDistributionV1 = Google::Apis::FirebaseappdistributionV1
-
       def self.run(params)
-        client = FirebaseAppDistributionV1::FirebaseAppDistributionService.new
-        client.authorization =
-          get_authorization(params[:service_credentials_file], params[:firebase_cli_token])
+        client = init_client(params[:service_credentials_file], params[:firebase_cli_token], params[:debug])
 
         if blank?(params[:alias])
           UI.user_error!("Must specify `alias`.")

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_get_latest_release.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_get_latest_release.rb
@@ -12,12 +12,8 @@ module Fastlane
       extend Auth::FirebaseAppDistributionAuthClient
       extend Helper::FirebaseAppDistributionHelper
 
-      FirebaseAppDistribution = Google::Apis::FirebaseappdistributionV1
-
       def self.run(params)
-        client = FirebaseAppDistribution::FirebaseAppDistributionService.new
-        client.authorization =
-          get_authorization(params[:service_credentials_file], params[:firebase_cli_token])
+        client = init_client(params[:service_credentials_file], params[:firebase_cli_token], params[:debug])
 
         UI.message("⏳ Fetching latest release for app #{params[:app]}...")
 

--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
@@ -64,6 +64,15 @@ module Fastlane
       def group_name(project_number, group_alias)
         "#{project_name(project_number)}/groups/#{group_alias}"
       end
+
+      def init_client(service_credentials_file, firebase_cli_token, debug = false)
+        Google::Apis::ClientOptions.default.log_http_requests = debug
+        Google::Apis::ClientOptions.default.application_name = "fastlane"
+        Google::Apis::ClientOptions.default.application_version = Fastlane::FirebaseAppDistribution::VERSION
+        client = Google::Apis::FirebaseappdistributionV1::FirebaseAppDistributionService.new
+        client.authorization = get_authorization(service_credentials_file, firebase_cli_token)
+        client
+      end
     end
   end
 end


### PR DESCRIPTION
Example `User-Agent` header containing client information

```
User-Agent: fastlane/0.6.1 google-apis-firebaseappdistribution_v1/0.3.0 Mac OS X/13.4.1 (gzip)
```