### PR TITLE
Set send_timeout on API client to fix upload_timeout param

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
@@ -65,7 +65,7 @@ module Fastlane
         "#{project_name(project_number)}/groups/#{group_alias}"
       end
 
-      def init_client(service_credentials_file, firebase_cli_token, debug = false)
+      def init_client(service_credentials_file, firebase_cli_token, debug, timeout = nil)
         if debug
           UI.important("Warning: Debug logging enabled. Output may include sensitive information.")
           Google::Apis.logger.level = Logger::DEBUG
@@ -73,6 +73,10 @@ module Fastlane
 
         Google::Apis::ClientOptions.default.application_name = "fastlane"
         Google::Apis::ClientOptions.default.application_version = Fastlane::FirebaseAppDistribution::VERSION
+        unless timeout.nil?
+          Google::Apis::ClientOptions.default.send_timeout_sec = timeout
+        end
+
         client = Google::Apis::FirebaseappdistributionV1::FirebaseAppDistributionService.new
         client.authorization = get_authorization(service_credentials_file, firebase_cli_token)
         client


### PR DESCRIPTION
We were setting `RequestOptions.max_elapsed_time` but that only sets the maximum time including retries. We also need to set `Google::Apis::ClientOptions.default.send_timeout_sec` to give the actual POST more time to finish: https://github.com/googleapis/google-api-ruby-client/blob/4c6c8a1e7c4a177e62660b79b526fe914aefa7ae/google-apis-core/lib/google/apis/options.rb#L58-L59