### PR TITLE
Validate credential account

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_auth_client.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_auth_client.rb
@@ -99,7 +99,10 @@ module Fastlane
       end
 
       def service_account(google_service_path, debug)
-        service_account_credentials = Google::Auth::ServiceAccountCredentials.make_creds(
+        # check if it's an external account or service account
+        json_file = JSON.parse(File.read(google_service_path))
+        auth = json_file["type"] == "external_account" ? Google::Auth::ExternalAccount::Credentials : Google::Auth::ServiceAccountCredentials
+        service_account_credentials = auth.make_creds(
           json_key_io: File.open(google_service_path),
           scope: SCOPE
         )


### PR DESCRIPTION
- Added validation to check whether it's an `external_account` or `service_account` to fix error `missing client_email` caused by https://github.com/googleapis/google-auth-library-ruby/blob/main/lib/googleauth/json_key_reader.rb#L24 when using Workload Identity Federation
  - `service_account` –> `Google::Auth::ServiceAccountCredentials`
  - `external_account` –> `Google::Auth::ExternalAccount::Credentials`
- Fix tests