### PR TITLE
Inline `init_client`

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -2,6 +2,7 @@ require 'fastlane/action'
 require 'open3'
 require 'shellwords'
 require 'googleauth'
+require 'google/apis/firebaseappdistribution_v1'
 require_relative '../helper/firebase_app_distribution_helper'
 require_relative '../helper/firebase_app_distribution_error_message'
 require_relative '../helper/firebase_app_distribution_auth_client'
@@ -37,10 +38,9 @@ module Fastlane
 
         # TODO(lkellogg): This sets the send timeout for all POST requests made by the client, but
         # ideally the timeout should only apply to the binary upload
-        client = init_v1_client(params[:service_credentials_file],
-                                params[:firebase_cli_token],
-                                params[:debug],
-                                timeout)
+        init_google_api_client(params[:debug], timeout)
+        client = Google::Apis::FirebaseappdistributionV1::FirebaseAppDistributionService.new
+        client.authorization = get_authorization(params[:service_credentials_file], params[:firebase_cli_token], params[:debug])
 
         # If binary is an AAB, get the AAB info for this app, which includes the integration state
         # and certificate data

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_add_testers_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_add_testers_action.rb
@@ -1,6 +1,6 @@
 require 'fastlane/action'
 require 'fastlane_core/ui/ui'
-
+require 'google/apis/firebaseappdistribution_v1'
 require_relative '../helper/firebase_app_distribution_helper'
 require_relative '../helper/firebase_app_distribution_auth_client'
 
@@ -11,7 +11,9 @@ module Fastlane
       extend Helper::FirebaseAppDistributionHelper
 
       def self.run(params)
-        client = init_v1_client(params[:service_credentials_file], params[:firebase_cli_token], params[:debug])
+        init_google_api_client(params[:debug])
+        client = Google::Apis::FirebaseappdistributionV1::FirebaseAppDistributionService.new
+        client.authorization = get_authorization(params[:service_credentials_file], params[:firebase_cli_token], params[:debug])
 
         if blank?(params[:emails]) && blank?(params[:file])
           UI.user_error!("Must specify `emails` or `file`.")

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_create_group_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_create_group_action.rb
@@ -1,7 +1,6 @@
 require 'fastlane/action'
 require 'fastlane_core/ui/ui'
 require 'google/apis/firebaseappdistribution_v1'
-
 require_relative '../helper/firebase_app_distribution_helper'
 require_relative '../helper/firebase_app_distribution_auth_client'
 
@@ -20,7 +19,9 @@ module Fastlane
           UI.user_error!("Must specify `display_name`.")
         end
 
-        client = init_v1_client(params[:service_credentials_file], params[:firebase_cli_token], params[:debug])
+        init_google_api_client(params[:debug])
+        client = Google::Apis::FirebaseappdistributionV1::FirebaseAppDistributionService.new
+        client.authorization = get_authorization(params[:service_credentials_file], params[:firebase_cli_token], params[:debug])
 
         project_number = params[:project_number]
         group_alias = params[:alias]

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_delete_group_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_delete_group_action.rb
@@ -1,6 +1,6 @@
 require 'fastlane/action'
 require 'fastlane_core/ui/ui'
-
+require 'google/apis/firebaseappdistribution_v1'
 require_relative '../helper/firebase_app_distribution_helper'
 require_relative '../helper/firebase_app_distribution_auth_client'
 
@@ -11,7 +11,9 @@ module Fastlane
       extend Helper::FirebaseAppDistributionHelper
 
       def self.run(params)
-        client = init_v1_client(params[:service_credentials_file], params[:firebase_cli_token], params[:debug])
+        init_google_api_client(params[:debug])
+        client = Google::Apis::FirebaseappdistributionV1::FirebaseAppDistributionService.new
+        client.authorization = get_authorization(params[:service_credentials_file], params[:firebase_cli_token], params[:debug])
 
         if blank?(params[:alias])
           UI.user_error!("Must specify `alias`.")

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_get_latest_release.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_get_latest_release.rb
@@ -13,7 +13,9 @@ module Fastlane
       extend Helper::FirebaseAppDistributionHelper
 
       def self.run(params)
-        client = init_v1_client(params[:service_credentials_file], params[:firebase_cli_token], params[:debug])
+        init_google_api_client(params[:debug])
+        client = Google::Apis::FirebaseappdistributionV1::FirebaseAppDistributionService.new
+        client.authorization = get_authorization(params[:service_credentials_file], params[:firebase_cli_token], params[:debug])
 
         UI.message("⏳ Fetching latest release for app #{params[:app]}...")
 

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_get_udids.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_get_udids.rb
@@ -2,6 +2,7 @@ require 'fastlane/action'
 require 'open3'
 require 'shellwords'
 require 'googleauth'
+require 'google/apis/firebaseappdistribution_v1alpha'
 require_relative '../helper/firebase_app_distribution_helper'
 require_relative '../helper/firebase_app_distribution_error_message'
 require_relative '../helper/firebase_app_distribution_auth_client'
@@ -13,7 +14,9 @@ module Fastlane
       extend Helper::FirebaseAppDistributionHelper
 
       def self.run(params)
-        client = init_v1alpha_client(params[:service_credentials_file], params[:firebase_cli_token], params[:debug])
+        init_google_api_client(params[:debug])
+        client = Google::Apis::FirebaseappdistributionV1alpha::FirebaseAppDistributionService.new
+        client.authorization = get_authorization(params[:service_credentials_file], params[:firebase_cli_token], params[:debug])
 
         project_number = params[:project_number]
         if blank?(project_number)

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_remove_testers_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_remove_testers_action.rb
@@ -1,6 +1,6 @@
 require 'fastlane/action'
 require 'fastlane_core/ui/ui'
-
+require 'google/apis/firebaseappdistribution_v1'
 require_relative '../helper/firebase_app_distribution_helper'
 require_relative '../helper/firebase_app_distribution_auth_client'
 
@@ -11,7 +11,9 @@ module Fastlane
       extend Helper::FirebaseAppDistributionHelper
 
       def self.run(params)
-        client = init_v1_client(params[:service_credentials_file], params[:firebase_cli_token], params[:debug])
+        init_google_api_client(params[:debug])
+        client = Google::Apis::FirebaseappdistributionV1::FirebaseAppDistributionService.new
+        client.authorization = get_authorization(params[:service_credentials_file], params[:firebase_cli_token], params[:debug])
 
         if blank?(params[:emails]) && blank?(params[:file])
           UI.user_error!("Must specify `emails` or `file`.")

--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
@@ -1,6 +1,4 @@
 require 'fastlane_core/ui/ui'
-require 'google/apis/firebaseappdistribution_v1'
-require 'google/apis/firebaseappdistribution_v1alpha'
 require 'cfpropertylist'
 
 module Fastlane
@@ -72,17 +70,7 @@ module Fastlane
         "#{project_name(project_number)}/groups/#{group_alias}"
       end
 
-      def init_v1_client(service_credentials_file, firebase_cli_token, debug, timeout = nil)
-        init_client(Google::Apis::FirebaseappdistributionV1::FirebaseAppDistributionService.new,
-                    service_credentials_file, firebase_cli_token, debug, timeout)
-      end
-
-      def init_v1alpha_client(service_credentials_file, firebase_cli_token, debug, timeout = nil)
-        init_client(Google::Apis::FirebaseappdistributionV1alpha::FirebaseAppDistributionService.new,
-                    service_credentials_file, firebase_cli_token, debug, timeout)
-      end
-
-      def init_client(client, service_credentials_file, firebase_cli_token, debug, timeout = nil)
+      def init_google_api_client(debug, timeout = nil)
         if debug
           UI.important("Warning: Debug logging enabled. Output may include sensitive information.")
           Google::Apis.logger.level = Logger::DEBUG
@@ -93,9 +81,6 @@ module Fastlane
         unless timeout.nil?
           Google::Apis::ClientOptions.default.send_timeout_sec = timeout
         end
-
-        client.authorization = get_authorization(service_credentials_file, firebase_cli_token, debug)
-        client
       end
 
       def deep_symbolize_keys(hash)


### PR DESCRIPTION
 This is in preparation for actions which need both, the `v1` and `v1alpha` clients, and should call `init_google_api_client` and `get_authorization only` once.