### PR TITLE
Don't throw an exception if there are no testers with UDIDs

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_get_udids.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_get_udids.rb
@@ -28,8 +28,9 @@ module Fastlane
         end
         udids = client.get_project_tester_udids(project_name(project_number)).tester_udids
 
-        if udids.empty?
-          UI.important("App Distribution fetched 0 tester UDIDs. Nothing written to output file.")
+        if udids.to_a.empty?
+          File.delete(params[:output_file]) if File.exist?(params[:output_file])
+          UI.important("App Distribution fetched 0 tester UDIDs. Removed output file.")
         else
           write_udids_to_file(udids, params[:output_file])
           UI.success("🎉 App Distribution tester UDIDs written to: #{params[:output_file]}")

--- a/lib/fastlane/plugin/firebase_app_distribution/version.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module FirebaseAppDistribution
-    VERSION = "0.9.0.pre.3"
+    VERSION = "0.9.0.pre.4"
   end
 end


### PR DESCRIPTION
- Don't throw an exception if there are no testers with UDIDs (fixes #362) - instead delete the UDID output file
- bump version to 0.9.0.pre.4
