### PR TITLE
Changes from API review (bump to 0.9.0.pre.5)

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -88,7 +88,7 @@ module Fastlane
           get_value_from_value_or_file(params[:test_devices], params[:test_devices_file])
         if present?(test_devices)
           UI.message("🤖 Starting automated tests. Note: This feature is in beta.")
-          test_password = get_value_from_value_or_file(params[:test_password], params[:test_password_file])
+          test_password = test_password_from_params(params)
           release_test = test_release(alpha_client, release, test_devices, params[:test_username], test_password, params[:test_username_resource], params[:test_password_resource])
           unless params[:test_non_blocking]
             poll_test_finished(alpha_client, release_test.name)
@@ -132,6 +132,12 @@ module Fastlane
       # supports markdown.
       def self.details
         "Release your beta builds with Firebase App Distribution"
+      end
+
+      def self.test_password_from_params(params)
+        test_password = get_value_from_value_or_file(params[:test_password], params[:test_password_file])
+        # Remove trailing newline if present
+        test_password && test_password.sub(/\r?\n$/, "")
       end
 
       def self.app_id_from_params(params)

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -529,7 +529,7 @@ module Fastlane
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :test_password,
                                        env_name: "FIREBASEAPPDISTRO_TEST_PASSWORD",
-                                       description: "Password for automatic login. If using a real password consider using test_password_file or setting FIREBASEAPPDISTRO_TEST_PASSWORD to avoid exposing sensitive info.",
+                                       description: "Password for automatic login. If using a real password consider using test_password_file or setting FIREBASEAPPDISTRO_TEST_PASSWORD to avoid exposing sensitive info",
                                        optional: true,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :test_password_file,

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -88,8 +88,9 @@ module Fastlane
           get_value_from_value_or_file(params[:test_devices], params[:test_devices_file])
         if present?(test_devices)
           UI.message("🤖 Starting automated tests. Note: This feature is in beta.")
-          release_test = test_release(alpha_client, release, test_devices, params[:test_username], params[:test_password], params[:test_username_resource], params[:test_password_resource])
-          unless params[:test_async]
+          test_password = get_value_from_value_or_file(params[:test_password], params[:test_password_file])
+          release_test = test_release(alpha_client, release, test_devices, params[:test_username], test_password, params[:test_username_resource], params[:test_password_resource])
+          unless params[:test_non_blocking]
             poll_test_finished(alpha_client, release_test.name)
           end
         end
@@ -522,23 +523,33 @@ module Fastlane
                                        optional: true,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :test_username,
+                                       env_name: "FIREBASEAPPDISTRO_TEST_USERNAME",
                                        description: "Username for automatic login",
                                        optional: true,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :test_password,
-                                       description: "Password for automatic login",
+                                       env_name: "FIREBASEAPPDISTRO_TEST_PASSWORD",
+                                       description: "Password for automatic login. If using a real password consider using test_password_file or setting FIREBASEAPPDISTRO_TEST_PASSWORD to avoid exposing sensitive info.",
                                        optional: true,
                                        type: String),
+          FastlaneCore::ConfigItem.new(key: :test_password_file,
+                                       env_name: "FIREBASEAPPDISTRO_TEST_PASSWORD_FILE",
+                                      description: "Path to file containing password for automatic login",
+                                      optional: true,
+                                      type: String),
           FastlaneCore::ConfigItem.new(key: :test_username_resource,
+                                       env_name: "FIREBASEAPPDISTRO_TEST_USERNAME_RESOURCE",
                                        description: "Resource name for the username field for automatic login",
                                        optional: true,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :test_password_resource,
+                                       env_name: "FIREBASEAPPDISTRO_TEST_PASSWORD_RESOURCE",
                                        description: "Resource name for the password field for automatic login",
                                        optional: true,
                                        type: String),
-          FastlaneCore::ConfigItem.new(key: :test_async,
-                                       description: "Run tests asynchronously. Visit the Firebase console for the automatic test results",
+          FastlaneCore::ConfigItem.new(key: :test_non_blocking,
+                                       env_name: "FIREBASEAPPDISTRO_TEST_NON_BLOCKING",
+                                       description: "Run automated tests without waiting for them to finish. Visit the Firebase console for the test results",
                                        optional: false,
                                        default_value: false,
                                        type: Boolean),

--- a/lib/fastlane/plugin/firebase_app_distribution/version.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module FirebaseAppDistribution
-    VERSION = "0.9.0.pre.4"
+    VERSION = "0.9.0.pre.5"
   end
 end

--- a/spec/firebase_app_distribution_action_spec.rb
+++ b/spec/firebase_app_distribution_action_spec.rb
@@ -561,7 +561,7 @@ describe Fastlane::Actions::FirebaseAppDistributionAction do
                            test_username: 'username',
                            test_password: 'password',
                            test_devices: 'model=model1,version=version1,locale=locale1,orientation=orientation1',
-                           test_async: true
+                           test_non_blocking: true
                          })
             end
 
@@ -580,7 +580,7 @@ describe Fastlane::Actions::FirebaseAppDistributionAction do
                            test_username: 'username',
                            test_password: 'password',
                            test_devices: 'model=model1,version=version1,locale=locale1,orientation=orientation1',
-                           test_async: true
+                           test_non_blocking: true
                          })
             end
 
@@ -610,7 +610,7 @@ describe Fastlane::Actions::FirebaseAppDistributionAction do
                                               app: android_app_id,
                                               android_artifact_path: 'path/to.apk',
                                               test_devices: devices,
-                                              test_async: true
+                                              test_non_blocking: true
                                             })
             end
           end


### PR DESCRIPTION
Changes from API review:
- Add `test_password_file` option
- Change `test_async` to `test_non_blocking`

Also:
- Add environment variable options for all new options, which is useful at least for `test_password`