### PR TITLE
Better handle errors when uploading binary

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -292,7 +292,7 @@ module Fastlane
         rescue Google::Apis::Error => err
           case err.status_code.to_i
           when 403
-            UI.crash!("#{ErrorMessage::PERMISSION_DENIED_ERROR}")
+            UI.crash!(ErrorMessage::PERMISSION_DENIED_ERROR)
           else
             UI.crash!("#{ErrorMessage.upload_binary_error(binary_type)} (#{err}, status_code: #{err.status_code})")
           end

--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_error_message.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_error_message.rb
@@ -4,6 +4,8 @@ module ErrorMessage
   SERVICE_CREDENTIALS_NOT_FOUND = "Service credentials file does not exist. Please check the service credentials path and try again."
   PARSE_SERVICE_CREDENTIALS_ERROR = "Failed to extract service account information from the service credentials file."
   PARSE_FIREBASE_TOOLS_JSON_ERROR = "Encountered error parsing json file. Ensure the firebase-tools.json file is formatted correctly."
+  PERMISSION_DENIED_ERROR = "The authenticated user does not have the required permissions on the Firebase project"
+  UPLOAD_BINARY_ERROR = "App Distribution halted because it had a problem uploading the app binary."
   UPLOAD_RELEASE_NOTES_ERROR = "App Distribution halted because it had a problem uploading release notes."
   UPLOAD_TESTERS_ERROR = "App Distribution halted because it had a problem adding testers/groups."
   GET_RELEASE_TIMEOUT = "App Distribution failed to fetch release information."


### PR DESCRIPTION
Unlike all the other API calls, binary upload uses `client.http()`. The errors returned by that method are not as nicely string-ified, so this PR returns a nice permissions error message in the case of a 403, and otherwise explicitly prints out the `status_code` in the message. This addresses #374