### PR TITLE
Make sure `platform` is a symbol

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -121,7 +121,7 @@ Layout/SpaceAroundOperators:
   Exclude:
   - "**/spec/actions_specs/xcodebuild_spec.rb"
 AllCops:
-  TargetRubyVersion: 2.0
+  TargetRubyVersion: 2.3
   Include:
   - "*/lib/assets/*Template"
   - "*/lib/assets/*TemplateAndroid"

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -13,6 +13,8 @@ module Fastlane
     module SharedValues
       FIREBASE_APP_DISTRO_RELEASE ||= :FIREBASE_APP_DISTRO_RELEASE
     end
+
+    # rubocop:disable Metrics/ClassLength
     class FirebaseAppDistributionAction < Action
       extend Auth::FirebaseAppDistributionAuthClient
       extend Helper::FirebaseAppDistributionHelper

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -163,7 +163,7 @@ module Fastlane
 
       def self.lane_platform
         # to_sym shouldn't be necessary, but possibly fixes #376
-        Actions.lane_context[Actions::SharedValues::PLATFORM_NAME].to_sym
+        Actions.lane_context[Actions::SharedValues::PLATFORM_NAME]&.to_sym
       end
 
       def self.platform_from_app_id(app_id)

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -13,8 +13,6 @@ module Fastlane
     module SharedValues
       FIREBASE_APP_DISTRO_RELEASE ||= :FIREBASE_APP_DISTRO_RELEASE
     end
-
-    # rubocop:disable Metrics/ClassLength
     class FirebaseAppDistributionAction < Action
       extend Auth::FirebaseAppDistributionAuthClient
       extend Helper::FirebaseAppDistributionHelper
@@ -195,7 +193,7 @@ module Fastlane
                  Dir[File.join("app", "build", "outputs", "apk", "release", "app-release.apk")].last
         end
 
-        UI.error "Unable to determine binary path for unsupported platform #{platform}."
+        UI.error("Unable to determine binary path for unsupported platform #{platform}.")
         nil
       end
 

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -162,7 +162,8 @@ module Fastlane
       end
 
       def self.lane_platform
-        Actions.lane_context[Actions::SharedValues::PLATFORM_NAME]
+        # to_sym shouldn't be necessary, but possibly fixes #376
+        Actions.lane_context[Actions::SharedValues::PLATFORM_NAME].to_sym
       end
 
       def self.platform_from_app_id(app_id)
@@ -193,6 +194,9 @@ module Fastlane
                  Dir["*.apk"].last ||
                  Dir[File.join("app", "build", "outputs", "apk", "release", "app-release.apk")].last
         end
+
+        UI.error "Unable to determine binary path for unsupported platform #{platform}."
+        nil
       end
 
       def self.get_upload_timeout(params)
@@ -586,11 +590,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        # Adjust this if your plugin only works for a particular platform (iOS vs. Android, for example)
-        # See: https://docs.fastlane.tools/advanced/#control-configuration-by-lane-and-by-platform
-        #
-        # [:ios, :mac, :android].include?(platform)
-        true
+        [:ios, :android].include?(platform)
       end
 
       def self.example_code


### PR DESCRIPTION
- Call `to_sym` on `[lane_context[PLATFORM_NAME]` (hopefully fixes #376).
- Explicitly only support iOS and Android.