### PR TITLE
Also support newlines as separator…

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -393,7 +393,7 @@ module Fastlane
           end
         end
 
-        device_executions = string_to_array(test_devices, ';').map do |td_string|
+        device_executions = string_to_array(test_devices, /[;\n]/).map do |td_string|
           td_hash = parse_test_device_string(td_string)
           Google::Apis::FirebaseappdistributionV1alpha::GoogleFirebaseAppdistroV1alphaDeviceExecution.new(
             device: Google::Apis::FirebaseappdistributionV1alpha::GoogleFirebaseAppdistroV1alphaTestDevice.new(

--- a/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/helper/firebase_app_distribution_helper.rb
@@ -30,7 +30,7 @@ module Fastlane
 
       # Returns the array representation of a string with trimmed comma
       # seperated values.
-      def string_to_array(string, delimiter = ",")
+      def string_to_array(string, delimiter = /[,\n]/)
         return [] if string.nil?
         # Strip string and then strip individual values
         string.strip.split(delimiter).map(&:strip)

--- a/spec/firebase_app_distribution_helper_spec.rb
+++ b/spec/firebase_app_distribution_helper_spec.rb
@@ -84,6 +84,16 @@ describe Fastlane::Helper::FirebaseAppDistributionHelper do
       array = helper.string_to_array(" ")
       expect(array).to eq([])
     end
+
+    it 'returns an array when the string is seperated by newlines' do
+      array = helper.string_to_array("string1\n   string2  \nstring3\n")
+      expect(array).to eq(%w[string1 string2 string3])
+    end
+
+    it 'returns an array when the string is seperated by semicolons and/or newlines when asked to do so' do
+      array = helper.string_to_array("string1;string2\nstring3\n", /[;\n]/)
+      expect(array).to eq(%w[string1 string2 string3])
+    end
   end
 
   describe '#get_ios_app_id_from_archive_plist' do


### PR DESCRIPTION
… for testers, groups, devices, and test case IDs files.